### PR TITLE
ci: defer composabl installation to slim down the image size and allow devcontainer install

### DIFF
--- a/.github/workflows/build-golden-image-wsl.yaml
+++ b/.github/workflows/build-golden-image-wsl.yaml
@@ -16,8 +16,8 @@ name: 🪙 Golden Image - WSL
 on:
   workflow_dispatch:
   # Run weekly on Mondays
-  # schedule:
-  #   - cron: "0 0 * * 1"
+  schedule:
+    - cron: "0 0 * * 1"
   push:
     branches:
       - main

--- a/golden-images/packer/devcontainer.pkr.hcl
+++ b/golden-images/packer/devcontainer.pkr.hcl
@@ -103,7 +103,7 @@ build {
         scripts         = [
             "${path.root}/scripts/installers/user/zsh.sh",
             "${path.root}/scripts/installers/user/pyenv.sh",
-            "${path.root}/scripts/installers/user/composabl.sh",
+            // "${path.root}/scripts/installers/user/composabl.sh",
             "${path.root}/scripts/installers/user/bashrc.sh",
         ]
     }

--- a/golden-images/packer/scripts/installers/user/bashrc.sh
+++ b/golden-images/packer/scripts/installers/user/bashrc.sh
@@ -18,3 +18,6 @@ echo "sudo service docker start" >> /home/${SSH_USER}/.bashrc
 # Init PyEnv
 echo "source ~/.pyenvrc" >> /home/${SSH_USER}/.zshrc
 echo "source ~/.pyenvrc" >> /home/${SSH_USER}/.bashrc
+
+# Install Composabl
+pip install --upgrade composabl


### PR DESCRIPTION
Currently there is an issue with the installation as there is not enough space to unpack the layers. 

```
[2B2023-10-17 08:20:24.839Z: docker: failed to register layer: ApplyLayer exit status 1 stdout:  stderr: write /usr/local/lib/python3.8/site-packages/nvidia/cusolver/lib/libcusolver.so.11: no space left on device.
```